### PR TITLE
Update example dir to use BigNum v0.4.0.

### DIFF
--- a/example/Nargo.toml
+++ b/example/Nargo.toml
@@ -6,4 +6,4 @@ compiler_version = ">=0.35.0"
 
 [dependencies]
 rsa = { path = "../lib" }
-bignum = { tag = "v0.3.6", git = "https://github.com/noir-lang/noir-bignum" }
+bignum = { tag = "v0.4.0", git = "https://github.com/noir-lang/noir-bignum" }

--- a/example/Nargo.toml
+++ b/example/Nargo.toml
@@ -2,7 +2,7 @@
 name = "example"
 type = "bin"
 authors = [""]
-compiler_version = ">=0.35.0"
+compiler_version = ">=0.36.0"
 
 [dependencies]
 rsa = { path = "../lib" }

--- a/example/src/main.nr
+++ b/example/src/main.nr
@@ -27,7 +27,7 @@ fn main(
 #[test]
 fn test_main() {
     // Create runtime params:
-    let has_multiplicative_inverse = false;
+    let has_multiplicative_inverse = true;
     let modulus_limbs = [
         0x413f4f8b6405fdb76f85540f5663c5,
         0x1dffa8aaa6192d9f031a8c1d55dc33,

--- a/example/src/main.nr
+++ b/example/src/main.nr
@@ -1,33 +1,129 @@
-use dep::bignum::BigNum;
-use dep::bignum::runtime_bignum::BigNumInstance;
-use dep::std;
+// use dep::bignum::BigNum;
+use dep::bignum::RuntimeBigNum;
+use dep::bignum::params::BigNumParams;
 
-use dep::rsa::types::{RSA, RSA2048, BN2048, BNInst2048};
+// use dep::std;
 
-fn main(bn: [[Field; 18]; 2], hash: [u8; 32], signature: BN2048) {
-    let rsa: RSA2048 = RSA {};
+use dep::rsa::types::{RBN2048};
+use dep::rsa::rsa::verify_sha256_pkcs1v15;
 
-    let BNInstance: BNInst2048 = BigNumInstance::new(bn[0], bn[1]);
+// If you uncomment this and the corresponding call to it in the test, you'll see an error. I don't understand why that error is so.
+// fn main(hash: [u8; 32], signature: RuntimeBigNum<18, 2048>) {
+//     assert(verify_sha256_pkcs1v15(hash, signature, 65537));
+// }
 
-    assert(rsa.verify_sha256_pkcs1v15(BNInstance, hash, signature, 65537));
+// Workaround to the above error: pass the signature and its params as arrays, instead of as a pretty RuntimeBigNum struct. Sad face.
+fn main(hash: [u8; 32], signature_limbs: [Field; 18], params_tuple: (bool, [Field; 18], [Field; 18])) {
+    // Ugly reconstitution of the params, because of a compile-time error trying to pass `signature: RuntimeBigNum` as a param to `main` directly.
+    let params: BigNumParams<18, 2048> = BigNumParams::new(params_tuple.0, params_tuple.1, params_tuple.2);
+
+    let signature = RuntimeBigNum::from_array(params, signature_limbs);
+
+    assert(verify_sha256_pkcs1v15(hash, signature, 65537));
 }
 
 #[test]
 fn test_main() {
+    // Create runtime params:
+    let has_multiplicative_inverse = false;
+    let modulus_limbs = [
+            0x413f4f8b6405fdb76f85540f5663c5,
+            0x1dffa8aaa6192d9f031a8c1d55dc33,
+            0xefccc1c3eb6c189c147cd485f56771,
+            0xc62eaf58cfd1a6eead6ec82e44111a,
+            0xf693ea8b22a50265d43eb2235d910b,
+            0x6eb385b77042a98e1f708a5b76fa17,
+            0xad5ad6b87eea566a26a05f5a59713b,
+            0x979c5611b54a78df8fd0b5b0464de6,
+            0xfde57bd223c394f50249f18d5522aa,
+            0xc6cd804f8bac07c9e81cc06fe323e9,
+            0x84ec399cf67c012f58a7b81515b63d,
+            0x61eba631d274a78a5387d0e2929d77,
+            0x40e2bb193409130671ac8f3e7c1fcf,
+            0x2aa7d8d4aec0cf96ad8fe0d0779dbb,
+            0x26d56c517952712bcdf1e8f1ffafc6,
+            0x9786e9f338cb9e6de55c436153978a,
+            0xb867413d06a32724b33657bbf1e3f2,
+            0xe8,
+        ];
+    let redc_limbs = [
+            0xbc5184dd6dc06d396240375a5211c0,
+            0x6280f148f5356bbea76382819bf475,
+            0x93d5ca8016d2335de4fc0988e7e24b,
+            0xd96e4c1d3210702c33d6470e16cfa0,
+            0xe2dbfaf8d02d4251862905787f2561,
+            0x9538f84fa231c9baac81216e2d9ed5,
+            0xcb82246c4a83da9398570aaabd4d2a,
+            0x94b04ca9ae375eebbb9c87479d3bee,
+            0x7deacf1e79cfe70937e9eee7ed887a,
+            0xa0f7bae3d1a70b98538142db43a58b,
+            0xaac2ec033a9ab117f077e3e06ba954,
+            0x4f937780ab7d644c95d1a34dcf450a,
+            0xc17dd532df051696582c85316a2517,
+            0x69f59bbbfa26851603d97da9a83709,
+            0xc506921f809dcbb4c07aea96102050,
+            0xbe638141f7b4d62660d59519ebdacf,
+            0xbc084a1b1ca76abe6f8ae8fcff6417,
+            0x1199,
+        ];
+    let params: BigNumParams<18, 2048> = BigNumParams::new(has_multiplicative_inverse, modulus_limbs, redc_limbs);
+
+    let signature_limbs = [
+            0x33aee5bd60a8d0664fe7780b7fde43,
+            0xc66f8a5fc4a74d18b83b27da6d4e04,
+            0x501c489c1764ad72e5c5b1bb56f1c6,
+            0xb1a8c5029f8422efdcfd1621f70da9,
+            0xe9b80989d178e8852266a7631c3b99,
+            0xb95a3af119a4ca60350a31ad3b9d7e,
+            0x64a98fdbb8441abc103fe2617149d9,
+            0xfd5a9db30568b2b151bd243b1816a9,
+            0x12d2be80d5959660831cc3b7929159,
+            0xae6034247561d3dfa882ca20d61ff6,
+            0x786973219800b65edd92b0b0b05d09,
+            0x516fdbed6a0d7afa3516dbba1ea473,
+            0x2f14e2807fa6c3d9cc5b7667aec5ac,
+            0x9a6a1997e1f7cfdeac736073ec4ce2,
+            0x24c94d7ea832e1afc889e82bd42c1b,
+            0x4cfb977a1102edca719f9c2e3f2c2e,
+            0x7c7cd4f29c3da09f7fa8ddf73df0b2,
+            0x77,
+        ];
+    
+    let signature: RuntimeBigNum<18, 2048> = RuntimeBigNum::from_array(
+        params,
+        signature_limbs
+    );
+
     // Output of `cargo run -- --msg "hello world"` in the `signature_gen` directory
     let hash: [u8; 32] = dep::std::hash::sha256("hello world".as_bytes());
-    let signature: BN2048 = BigNum::from_array(
-        [
-        0x33aee5bd60a8d0664fe7780b7fde43, 0xc66f8a5fc4a74d18b83b27da6d4e04, 0x501c489c1764ad72e5c5b1bb56f1c6, 0xb1a8c5029f8422efdcfd1621f70da9, 0xe9b80989d178e8852266a7631c3b99, 0xb95a3af119a4ca60350a31ad3b9d7e, 0x64a98fdbb8441abc103fe2617149d9, 0xfd5a9db30568b2b151bd243b1816a9, 0x12d2be80d5959660831cc3b7929159, 0xae6034247561d3dfa882ca20d61ff6, 0x786973219800b65edd92b0b0b05d09, 0x516fdbed6a0d7afa3516dbba1ea473, 0x2f14e2807fa6c3d9cc5b7667aec5ac, 0x9a6a1997e1f7cfdeac736073ec4ce2, 0x24c94d7ea832e1afc889e82bd42c1b, 0x4cfb977a1102edca719f9c2e3f2c2e, 0x7c7cd4f29c3da09f7fa8ddf73df0b2, 0x77
-    ]
+
+    /* COMMENT-OUT ONE OF THESE CALLS TO `main`. */
+
+    /* ATTEMPT 1 */
+
+    // This throws a compile error:
+    
+    // main(hash, signature);
+
+    /*
+    Getting this error, when trying to call this main (above).
+    error: Only sized types may be used in the entry point to a program
+    src/main.nr:10:36
+   
+    fn main(hash: [u8; 32], signature: RuntimeBigNum<18, 2048>) {
+    Slices, references, or any type containing them may not be used in main, contract functions, or foldable functions
+    */
+
+    /* ATTEMPT 2 */
+
+    // This succeeds:
+
+    let params_tuple: (bool, [Field; 18], [Field; 18]) = (
+        has_multiplicative_inverse,
+        modulus_limbs,
+        redc_limbs
     );
-    let bn = [
-        [
-            0x413f4f8b6405fdb76f85540f5663c5, 0x1dffa8aaa6192d9f031a8c1d55dc33, 0xefccc1c3eb6c189c147cd485f56771, 0xc62eaf58cfd1a6eead6ec82e44111a, 0xf693ea8b22a50265d43eb2235d910b, 0x6eb385b77042a98e1f708a5b76fa17, 0xad5ad6b87eea566a26a05f5a59713b, 0x979c5611b54a78df8fd0b5b0464de6, 0xfde57bd223c394f50249f18d5522aa, 0xc6cd804f8bac07c9e81cc06fe323e9, 0x84ec399cf67c012f58a7b81515b63d, 0x61eba631d274a78a5387d0e2929d77, 0x40e2bb193409130671ac8f3e7c1fcf, 0x2aa7d8d4aec0cf96ad8fe0d0779dbb, 0x26d56c517952712bcdf1e8f1ffafc6, 0x9786e9f338cb9e6de55c436153978a, 0xb867413d06a32724b33657bbf1e3f2, 0xe8
-        ],
-        [
-            0xbc5184dd6dc06d396240375a5211c0, 0x6280f148f5356bbea76382819bf475, 0x93d5ca8016d2335de4fc0988e7e24b, 0xd96e4c1d3210702c33d6470e16cfa0, 0xe2dbfaf8d02d4251862905787f2561, 0x9538f84fa231c9baac81216e2d9ed5, 0xcb82246c4a83da9398570aaabd4d2a, 0x94b04ca9ae375eebbb9c87479d3bee, 0x7deacf1e79cfe70937e9eee7ed887a, 0xa0f7bae3d1a70b98538142db43a58b, 0xaac2ec033a9ab117f077e3e06ba954, 0x4f937780ab7d644c95d1a34dcf450a, 0xc17dd532df051696582c85316a2517, 0x69f59bbbfa26851603d97da9a83709, 0xc506921f809dcbb4c07aea96102050, 0xbe638141f7b4d62660d59519ebdacf, 0xbc084a1b1ca76abe6f8ae8fcff6417, 0x1199
-        ]
-    ];
-    main(bn, hash, signature);
+
+    main(hash, signature_limbs, params_tuple);
+
 }

--- a/example/src/main.nr
+++ b/example/src/main.nr
@@ -1,11 +1,8 @@
-// use dep::bignum::BigNum;
 use dep::bignum::params::BigNumParams;
 use dep::bignum::RuntimeBigNum;
 
-// use dep::std;
-
 use dep::rsa::rsa::verify_sha256_pkcs1v15;
-use dep::rsa::types::RBN2048;
+use dep::rsa::types::RBN2048; // Used if we can solve the error described in comments below.
 
 // If you uncomment this and the corresponding call to it in the test, you'll see an error. I don't understand why that error is so.
 // fn main(hash: [u8; 32], signature: RuntimeBigNum<18, 2048>) {

--- a/example/src/main.nr
+++ b/example/src/main.nr
@@ -1,11 +1,11 @@
 // use dep::bignum::BigNum;
-use dep::bignum::RuntimeBigNum;
 use dep::bignum::params::BigNumParams;
+use dep::bignum::RuntimeBigNum;
 
 // use dep::std;
 
-use dep::rsa::types::{RBN2048};
 use dep::rsa::rsa::verify_sha256_pkcs1v15;
+use dep::rsa::types::RBN2048;
 
 // If you uncomment this and the corresponding call to it in the test, you'll see an error. I don't understand why that error is so.
 // fn main(hash: [u8; 32], signature: RuntimeBigNum<18, 2048>) {
@@ -13,9 +13,14 @@ use dep::rsa::rsa::verify_sha256_pkcs1v15;
 // }
 
 // Workaround to the above error: pass the signature and its params as arrays, instead of as a pretty RuntimeBigNum struct. Sad face.
-fn main(hash: [u8; 32], signature_limbs: [Field; 18], params_tuple: (bool, [Field; 18], [Field; 18])) {
+fn main(
+    hash: [u8; 32],
+    signature_limbs: [Field; 18],
+    params_tuple: (bool, [Field; 18], [Field; 18]),
+) {
     // Ugly reconstitution of the params, because of a compile-time error trying to pass `signature: RuntimeBigNum` as a param to `main` directly.
-    let params: BigNumParams<18, 2048> = BigNumParams::new(params_tuple.0, params_tuple.1, params_tuple.2);
+    let params: BigNumParams<18, 2048> =
+        BigNumParams::new(params_tuple.0, params_tuple.1, params_tuple.2);
 
     let signature = RuntimeBigNum::from_array(params, signature_limbs);
 
@@ -27,72 +32,70 @@ fn test_main() {
     // Create runtime params:
     let has_multiplicative_inverse = false;
     let modulus_limbs = [
-            0x413f4f8b6405fdb76f85540f5663c5,
-            0x1dffa8aaa6192d9f031a8c1d55dc33,
-            0xefccc1c3eb6c189c147cd485f56771,
-            0xc62eaf58cfd1a6eead6ec82e44111a,
-            0xf693ea8b22a50265d43eb2235d910b,
-            0x6eb385b77042a98e1f708a5b76fa17,
-            0xad5ad6b87eea566a26a05f5a59713b,
-            0x979c5611b54a78df8fd0b5b0464de6,
-            0xfde57bd223c394f50249f18d5522aa,
-            0xc6cd804f8bac07c9e81cc06fe323e9,
-            0x84ec399cf67c012f58a7b81515b63d,
-            0x61eba631d274a78a5387d0e2929d77,
-            0x40e2bb193409130671ac8f3e7c1fcf,
-            0x2aa7d8d4aec0cf96ad8fe0d0779dbb,
-            0x26d56c517952712bcdf1e8f1ffafc6,
-            0x9786e9f338cb9e6de55c436153978a,
-            0xb867413d06a32724b33657bbf1e3f2,
-            0xe8,
-        ];
+        0x413f4f8b6405fdb76f85540f5663c5,
+        0x1dffa8aaa6192d9f031a8c1d55dc33,
+        0xefccc1c3eb6c189c147cd485f56771,
+        0xc62eaf58cfd1a6eead6ec82e44111a,
+        0xf693ea8b22a50265d43eb2235d910b,
+        0x6eb385b77042a98e1f708a5b76fa17,
+        0xad5ad6b87eea566a26a05f5a59713b,
+        0x979c5611b54a78df8fd0b5b0464de6,
+        0xfde57bd223c394f50249f18d5522aa,
+        0xc6cd804f8bac07c9e81cc06fe323e9,
+        0x84ec399cf67c012f58a7b81515b63d,
+        0x61eba631d274a78a5387d0e2929d77,
+        0x40e2bb193409130671ac8f3e7c1fcf,
+        0x2aa7d8d4aec0cf96ad8fe0d0779dbb,
+        0x26d56c517952712bcdf1e8f1ffafc6,
+        0x9786e9f338cb9e6de55c436153978a,
+        0xb867413d06a32724b33657bbf1e3f2,
+        0xe8,
+    ];
     let redc_limbs = [
-            0xbc5184dd6dc06d396240375a5211c0,
-            0x6280f148f5356bbea76382819bf475,
-            0x93d5ca8016d2335de4fc0988e7e24b,
-            0xd96e4c1d3210702c33d6470e16cfa0,
-            0xe2dbfaf8d02d4251862905787f2561,
-            0x9538f84fa231c9baac81216e2d9ed5,
-            0xcb82246c4a83da9398570aaabd4d2a,
-            0x94b04ca9ae375eebbb9c87479d3bee,
-            0x7deacf1e79cfe70937e9eee7ed887a,
-            0xa0f7bae3d1a70b98538142db43a58b,
-            0xaac2ec033a9ab117f077e3e06ba954,
-            0x4f937780ab7d644c95d1a34dcf450a,
-            0xc17dd532df051696582c85316a2517,
-            0x69f59bbbfa26851603d97da9a83709,
-            0xc506921f809dcbb4c07aea96102050,
-            0xbe638141f7b4d62660d59519ebdacf,
-            0xbc084a1b1ca76abe6f8ae8fcff6417,
-            0x1199,
-        ];
-    let params: BigNumParams<18, 2048> = BigNumParams::new(has_multiplicative_inverse, modulus_limbs, redc_limbs);
+        0xbc5184dd6dc06d396240375a5211c0,
+        0x6280f148f5356bbea76382819bf475,
+        0x93d5ca8016d2335de4fc0988e7e24b,
+        0xd96e4c1d3210702c33d6470e16cfa0,
+        0xe2dbfaf8d02d4251862905787f2561,
+        0x9538f84fa231c9baac81216e2d9ed5,
+        0xcb82246c4a83da9398570aaabd4d2a,
+        0x94b04ca9ae375eebbb9c87479d3bee,
+        0x7deacf1e79cfe70937e9eee7ed887a,
+        0xa0f7bae3d1a70b98538142db43a58b,
+        0xaac2ec033a9ab117f077e3e06ba954,
+        0x4f937780ab7d644c95d1a34dcf450a,
+        0xc17dd532df051696582c85316a2517,
+        0x69f59bbbfa26851603d97da9a83709,
+        0xc506921f809dcbb4c07aea96102050,
+        0xbe638141f7b4d62660d59519ebdacf,
+        0xbc084a1b1ca76abe6f8ae8fcff6417,
+        0x1199,
+    ];
+    let params: BigNumParams<18, 2048> =
+        BigNumParams::new(has_multiplicative_inverse, modulus_limbs, redc_limbs);
 
     let signature_limbs = [
-            0x33aee5bd60a8d0664fe7780b7fde43,
-            0xc66f8a5fc4a74d18b83b27da6d4e04,
-            0x501c489c1764ad72e5c5b1bb56f1c6,
-            0xb1a8c5029f8422efdcfd1621f70da9,
-            0xe9b80989d178e8852266a7631c3b99,
-            0xb95a3af119a4ca60350a31ad3b9d7e,
-            0x64a98fdbb8441abc103fe2617149d9,
-            0xfd5a9db30568b2b151bd243b1816a9,
-            0x12d2be80d5959660831cc3b7929159,
-            0xae6034247561d3dfa882ca20d61ff6,
-            0x786973219800b65edd92b0b0b05d09,
-            0x516fdbed6a0d7afa3516dbba1ea473,
-            0x2f14e2807fa6c3d9cc5b7667aec5ac,
-            0x9a6a1997e1f7cfdeac736073ec4ce2,
-            0x24c94d7ea832e1afc889e82bd42c1b,
-            0x4cfb977a1102edca719f9c2e3f2c2e,
-            0x7c7cd4f29c3da09f7fa8ddf73df0b2,
-            0x77,
-        ];
-    
-    let signature: RuntimeBigNum<18, 2048> = RuntimeBigNum::from_array(
-        params,
-        signature_limbs
-    );
+        0x33aee5bd60a8d0664fe7780b7fde43,
+        0xc66f8a5fc4a74d18b83b27da6d4e04,
+        0x501c489c1764ad72e5c5b1bb56f1c6,
+        0xb1a8c5029f8422efdcfd1621f70da9,
+        0xe9b80989d178e8852266a7631c3b99,
+        0xb95a3af119a4ca60350a31ad3b9d7e,
+        0x64a98fdbb8441abc103fe2617149d9,
+        0xfd5a9db30568b2b151bd243b1816a9,
+        0x12d2be80d5959660831cc3b7929159,
+        0xae6034247561d3dfa882ca20d61ff6,
+        0x786973219800b65edd92b0b0b05d09,
+        0x516fdbed6a0d7afa3516dbba1ea473,
+        0x2f14e2807fa6c3d9cc5b7667aec5ac,
+        0x9a6a1997e1f7cfdeac736073ec4ce2,
+        0x24c94d7ea832e1afc889e82bd42c1b,
+        0x4cfb977a1102edca719f9c2e3f2c2e,
+        0x7c7cd4f29c3da09f7fa8ddf73df0b2,
+        0x77,
+    ];
+
+    let signature: RuntimeBigNum<18, 2048> = RuntimeBigNum::from_array(params, signature_limbs);
 
     // Output of `cargo run -- --msg "hello world"` in the `signature_gen` directory
     let hash: [u8; 32] = dep::std::hash::sha256("hello world".as_bytes());
@@ -102,28 +105,20 @@ fn test_main() {
     /* ATTEMPT 1 */
 
     // This throws a compile error:
-    
     // main(hash, signature);
-
     /*
     Getting this error, when trying to call this main (above).
     error: Only sized types may be used in the entry point to a program
     src/main.nr:10:36
-   
-    fn main(hash: [u8; 32], signature: RuntimeBigNum<18, 2048>) {
+   fn main(hash: [u8; 32], signature: RuntimeBigNum<18, 2048>) {
     Slices, references, or any type containing them may not be used in main, contract functions, or foldable functions
     */
 
     /* ATTEMPT 2 */
 
     // This succeeds:
-
-    let params_tuple: (bool, [Field; 18], [Field; 18]) = (
-        has_multiplicative_inverse,
-        modulus_limbs,
-        redc_limbs
-    );
+    let params_tuple: (bool, [Field; 18], [Field; 18]) =
+        (has_multiplicative_inverse, modulus_limbs, redc_limbs);
 
     main(hash, signature_limbs, params_tuple);
-
 }

--- a/lib/Nargo.toml
+++ b/lib/Nargo.toml
@@ -2,7 +2,7 @@
 name = "noir_rsa"
 type = "lib"
 authors = [""]
-compiler_version = ">=0.35.0"
+compiler_version = ">=0.36.0"
 
 [dependencies]
 bignum = {tag = "v0.4.0", git = "https://github.com/noir-lang/noir-bignum"}

--- a/lib/Nargo.toml
+++ b/lib/Nargo.toml
@@ -5,4 +5,4 @@ authors = [""]
 compiler_version = ">=0.35.0"
 
 [dependencies]
-bignum = {tag = "main", git = "https://github.com/noir-lang/noir-bignum"}
+bignum = {tag = "v0.4.0", git = "https://github.com/noir-lang/noir-bignum"}

--- a/lib/src/lib.nr
+++ b/lib/src/lib.nr
@@ -1,1 +1,2 @@
-mod rsa;
+pub mod rsa;
+pub mod types;

--- a/lib/src/rsa.nr
+++ b/lib/src/rsa.nr
@@ -1,5 +1,5 @@
-use dep::bignum::runtime_bignum::RuntimeBigNum;
 use dep::bignum::params::BigNumParams;
+use dep::bignum::runtime_bignum::RuntimeBigNum;
 global HASH_LEN: u32 = 32;
 
 fn reverse_array<let N: u32>(array: [u8; N]) -> [u8; N] {
@@ -135,7 +135,6 @@ pub fn verify_sha256_pss<let NumLimbs: u32, let ModBits: u32>(
     // Convert the exponentiated signature to a byte array and reverse it to
     // get it in big endian order, which is much easier to work with for
     // the rest of the verification process
-
     let em: [u8; (ModBits + 7) / 8] = reverse_array(exponentiated.to_le_bytes());
 
     // The modulus size in bits minus 1
@@ -368,7 +367,7 @@ fn test_verify_sha256_pkcs1v15_2048() {
             0x27910e77bdc54ba42a4322a5ce8200,
             0xc3b7b95e779c9a11895c88fe24bced,
             0x96,
-        ]
+        ],
     };
     assert(verify_sha256_pkcs1v15(sha256_hash, signature, 65537));
 }

--- a/lib/src/types.nr
+++ b/lib/src/types.nr
@@ -1,38 +1,7 @@
-use dep::bignum::BigNum;
-use dep::bignum::fields::Params2048;
-use dep::bignum::fields::Params1024;
-use dep::bignum::fields::Params4096;
-use dep::bignum::runtime_bignum::BigNumParamsTrait;
+use dep::bignum::RuntimeBigNum;
 
-struct RSA<let NumLimbs: u32, let NumBytes: u32> {}
-
-struct Params1025 {}
-impl BigNumParamsTrait<9> for Params1025 {
-    fn modulus_bits() -> u32 {
-        1025
-    }
-}
-
-struct Params1964 {}
-impl BigNumParamsTrait<17> for Params1964 {
-    fn modulus_bits() -> u32 {
-        1964
-    }
-}
-
-type BN1024 = BigNum<9, Params1024>;
-type BN1025 = BigNum<9, Params1025>;
-type BN1964 = BigNum<17, Params1964>;
-type BN2048 = BigNum<18, Params2048>;
-type BN4096 = BigNum<35, Params4096>;
-type BNInst1024 = BigNumInstance<9, Params1024>;
-type BNInst1025 = BigNumInstance<9, Params1025>;
-type BNInst1964 = BigNumInstance<17, Params1964>;
-type BNInst2048 = BigNumInstance<18, Params2048>;
-type BNInst4096 = BigNumInstance<35, Params4096>;
-
-type RSA1024 = RSA<BN1024, BNInst1024, 128>;
-type RSA1025 = RSA<BN1025, BNInst1025, 129>;
-type RSA1964 = RSA<BN1964, BNInst1964, 246>;
-type RSA2048 = RSA<BN2048, BNInst2048, 256>;
-type RSA4096 = RSA<BN4096, BNInst4096, 512>;
+pub type RBN1024 = RuntimeBigNum<9, 1024>;
+pub type RBN1025 = RuntimeBigNum<9, 1025>;
+pub type RBN1964 = RuntimeBigNum<17, 1946>;
+pub type RBN2048 = RuntimeBigNum<18, 2048>;
+pub type RBN4096 = RuntimeBigNum<35, 4096>;


### PR DESCRIPTION
I wanted to see what the code in the `example/` dir looks like when using the latest BigNum syntax. It's fairly clean. The only ugliness is that the `main` function doesn't seem to like our structs `RuntimeBigNum` or `BigNumParams` being passed to it, and I'm not sure why. So for now, I've opened this PR to exemplify the problem to the Noir team.

You'll notice: as per your message on slack, 5 of the 8 tests in `lib/` are failing, and we suspect this is a result of changes to bignum introduced in v0.3.7. I haven't tried to fix those tests here; that's a separate thing that we're trying to solve :) 

The changes in this PR are orthogonal to that problem: this PR just seeks to get the test in `example/` working, which it does.

**A note to the Noir team:**

Notice there is a commented-out `main` and a corresponding commented-out call to `main` within the test. If you swap the `main` and the corresponding call to `main`, you'll see an error like: 

<img width="569" alt="image" src="https://github.com/user-attachments/assets/be4e4fda-d8b4-4aff-927f-7def0ccfe592">

This error doesn't make sense to me, because `RuntimeBigNum<18, 2048>` is a concrete type, and none of its data members (nor the data members of nested structs) are slices or references, from what I can tell.

**Edit:** Interestingly (or frustratingly), the _test_ in `example/` succeeds with `nargo test`, but _compilation_ of this `main()` program _fails_ with:

<img width="547" alt="image" src="https://github.com/user-attachments/assets/3ac05dba-f722-45e2-8428-5a1b59e5b222">

**Edit Edit:** Actually, this compiler error only appears with nargo 0.37.0. If you use 0.36.0, this second-pictured compiler error succeeds. (But the first-pictured compiler error - if uncommented - still fails).


Tested with:

nargo version = 0.37.0

noirc version = 0.37.0+13856a121125b1ccca15919942081a5d157d280e

(git version hash: 13856a121125b1ccca15919942081a5d157d280e, is dirty: false)